### PR TITLE
New item Valuta

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -296,6 +296,10 @@ eon.utrustningsgrupper = {
     proviant: "Proviant"
 }
 
+eon.valuta = {
+    "valuta": "Valuta"
+}
+
 eon.djurgrupper = {
     litenvarelse: "Liten varelse",
     meddelstorvarelse: "Medelstor varelse",

--- a/module/datamodels/_module.js
+++ b/module/datamodels/_module.js
@@ -19,3 +19,5 @@ export {default as EonUtrustning} from "./item/utrustning.js";
 export {default as EonEgenskap} from "./item/egenskap.js";
 
 export {default as EonSkada} from "./item/skada.js";
+
+export {default as EonValuta} from "./item/valuta.js";

--- a/module/datamodels/item/valuta.js
+++ b/module/datamodels/item/valuta.js
@@ -1,0 +1,39 @@
+import foremal from "./base/foremal.js";
+
+/**
+ * Data schema for Currency (Valuta) items
+ * @extends {foremal}
+ */
+export default class EonValuta extends foremal {
+    /** @override */
+    static defineSchema() {
+        const fields = foundry.data.fields;
+        const schema = super.defineSchema();
+
+        schema.installningar = new fields.SchemaField({
+            buren: new fields.BooleanField({
+                required: true,
+                initial: false
+            })
+        });
+
+        schema.metall = new fields.StringField({
+            required: true,
+            initial: ""
+        });
+
+        schema.silver_varde = new fields.NumberField({
+            required: true,
+            nullable: false,
+            initial: 0,
+            min: 0
+        });
+
+        schema.ursprung = new fields.StringField({
+            required: true,
+            initial: ""
+        });
+
+        return schema;
+    }
+}

--- a/module/eon-rpg.js
+++ b/module/eon-rpg.js
@@ -7,6 +7,7 @@ import { eon } from "./config.js";
 import { systemSettings } from "./settings.js";
 import * as Templates from "./templates.js";
 import * as Migration from "./migration.js";
+import { datavaluta } from '../packs/valuta.js';
 
 /* ------------------------------------ */
 /* 1. Init system						*/
@@ -27,6 +28,7 @@ Hooks.once("init", async function() {
     CONFIG.Item.dataModels.Rustning = models.EonRustning;
     CONFIG.Item.dataModels.Utrustning = models.EonUtrustning;
     CONFIG.Item.dataModels.Skada = models.EonSkada;
+    CONFIG.Item.dataModels.Valuta = models.EonValuta;
 
     CONFIG.Item.dataModels.Egenskap = models.EonEgenskap;
 
@@ -42,6 +44,8 @@ Hooks.once("init", async function() {
     CONFIG.EON.settings.hinderenceSkillGroupMovement = game.settings.get("eon-rpg", "hinderenceAttributeMovement");
     CONFIG.EON.settings.textfont = game.settings.get("eon-rpg", "textfont");
     CONFIG.EON.settings.headlinefont = game.settings.get("eon-rpg", "headlinefont");
+
+    CONFIG.EON.datavaluta = datavaluta;
 
     Actors.unregisterSheet("core", ActorSheet);
     Actors.registerSheet("EON", sheets.EonActorSheet, { types: ["Rollperson"], makeDefault: true });

--- a/module/sheets/item-sheet.js
+++ b/module/sheets/item-sheet.js
@@ -233,6 +233,10 @@ export default class EonItemSheet extends ItemSheet {
 		html
             .find('.weapon-property')
             .click(this._setVapenEgenhet.bind(this));
+
+		html
+			.find('.currency-select')
+			.change(event => this._setCurrency(event));
 	}
 
 	/** @override */
@@ -794,6 +798,29 @@ export default class EonItemSheet extends ItemSheet {
 		const dataset = element.dataset;
 		const source = dataset.source;
 
+		if (source == "valuta") {
+			const selectedCurrencyName = element.value;
+			const currencyData = CONFIG.EON.datavaluta.valuta[selectedCurrencyName.toLowerCase()];
+			
+			if (!currencyData) {
+				ui.notifications.error("Valutan hittades inte");
+				return;
+			}
+			
+			const itemData = foundry.utils.duplicate(this.item);
+			itemData.name = currencyData.namn;
+			itemData.system.metall = currencyData.metall;
+			itemData.system.silver_varde = currencyData.silver_varde;
+			itemData.system.vikt = currencyData.vikt;
+			itemData.system.ursprung = currencyData.ursprung;
+			itemData.system.antal = this.item.system.antal || 0;
+			
+			await this.item.update(itemData);
+			this.render();
+			
+			return;
+		}
+
 		if (source == "weapon-close") {
 			const typ = this.item.system.grupp;
 			const vapenmall = element.value;
@@ -1112,6 +1139,28 @@ export default class EonItemSheet extends ItemSheet {
 			"system.varde.bonus": 0
 		});
     }
+
+	async _setCurrency(event) {
+		event.preventDefault();
+		const currencyKey = event.currentTarget.value.toLowerCase();
+		const currencyData = CONFIG.EON.datavaluta.valuta[currencyKey];
+		
+		if (currencyData) {
+			const itemData = {
+				name: currencyData.namn,
+				system: {
+					ursprung: currencyData.ursprung,
+					metall: currencyData.metall,
+					silver_varde: currencyData.silver_varde,
+					vikt: currencyData.vikt,
+					antal: this.item.system.antal || 0
+				}
+			};
+			
+			await this.item.update(itemData);
+			this.render();
+		}
+	}
 }
 
 // Helper function to format skill values

--- a/module/templates.js
+++ b/module/templates.js
@@ -5,6 +5,7 @@ import { datavapen } from "../packs/vapen.js";
 import { datastrid } from "../packs/strid.js";
 import { datautrustning } from "../packs/utrustning.js";
 import { datadjur } from "../packs/djur.js";
+import { datavaluta } from "../packs/valuta.js";
 
 /**
  * Define a set of template paths to pre-load
@@ -53,7 +54,8 @@ export const PreloadHandlebarsTemplates = async function () {
 		"systems/eon-rpg/templates/items/parts/items-spell-data.html",
 		"systems/eon-rpg/templates/items/parts/items-spell-ritual.html",		
 
-		"systems/eon-rpg/templates/items/parts/items-description.html"
+		"systems/eon-rpg/templates/items/parts/items-description.html",
+		"systems/eon-rpg/templates/items/valuta-sheet.html",
     ];
 
     /* Load the template parts
@@ -86,6 +88,9 @@ export async function Setup() {
 		Object.assign(importData, fileData);
 
 		fileData = datadjur;
+		Object.assign(importData, fileData);
+
+		fileData = datavaluta;
 		Object.assign(importData, fileData);
 
 		return importData;		
@@ -785,5 +790,44 @@ export const RegisterHandlebarsHelpers = function () {
 		else {
 			return;
 		}
+	});
+
+	Handlebars.registerHelper("getCurrencyData", function(valuta, property) {
+		if (!valuta || !property) {
+			return "";
+		}
+
+		if (CONFIG.EON.datavaluta?.valuta?.[valuta]?.[property] !== undefined) {
+			return CONFIG.EON.datavaluta.valuta[valuta][property];
+		}
+
+		return "";
+	});
+
+	Handlebars.registerHelper("getCurrencyList", function() {
+		if (!CONFIG.EON.datavaluta?.valuta) {
+			console.log("No currency data found");
+			return [];
+		}
+		
+		const currencyList = Object.entries(CONFIG.EON.datavaluta.valuta).map(([key, currency]) => {
+			const item = {
+				key: key,
+				namn: currency.namn,
+				ursprung: currency.ursprung,
+				displayNamn: `${currency.namn} (${currency.ursprung})`
+			};
+			return item;
+		});
+		
+		console.log("Currency list:", currencyList);
+		return currencyList;
+	});
+
+	Handlebars.registerHelper("formatDecimal", function(number) {
+		if (typeof number !== 'number') {
+			number = Number(number);
+		}
+		return number.toFixed(2);
 	});
 }

--- a/packs/valuta.js
+++ b/packs/valuta.js
@@ -1,0 +1,380 @@
+export const datavaluta = {
+    valuta: {
+        "guldlibra": {
+            "namn": "Guldlibra",
+            "enhet": "st",
+            "ursprung": "Jargien, Drunok",
+            "metall": "Guld",
+            "silver_varde": 240,
+            "vikt": 0.0227
+        },
+        "solidra": {
+            "namn": "Solidra",
+            "enhet": "st",
+            "ursprung": "Jargien, Drunok",
+            "metall": "Guld",
+            "silver_varde": 20,
+            "vikt": 0.0019
+        },
+        "denar": {
+            "namn": "Denar",
+            "enhet": "st",
+            "ursprung": "Jargien, Drunok",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "cupra": {
+            "namn": "Cupra",
+            "enhet": "st",
+            "ursprung": "Jargien, Drunok",
+            "metall": "Koppar",
+            "silver_varde": 0.1,
+            "vikt": 0.0007
+        },
+        "guldmark": {
+            "namn": "Guldmark",
+            "enhet": "st",
+            "ursprung": "Asharien, Soldarn",
+            "metall": "Guld",
+            "silver_varde": 160,
+            "vikt": 0.015
+        },
+        "gulden": {
+            "namn": "Gulden",
+            "enhet": "st",
+            "ursprung": "Asharien, Soldarn",
+            "metall": "Silver",
+            "silver_varde": 6,
+            "vikt": 0.011
+        },
+        "silverdaler": {
+            "namn": "Silverdaler",
+            "enhet": "st",
+            "ursprung": "Asharien, Soldarn",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "Koppar": {
+            "namn": "Koppar",
+            "enhet": "st",
+            "ursprung": "Asharien, Soldarn",
+            "metall": "Koppar",
+            "silver_varde": 0.1,
+            "vikt": 0.0007
+        },
+        "thaler": {
+            "namn": "Thaler",
+            "enhet": "st",
+            "ursprung": "Västmark",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "guldkrona": {
+            "namn": "Guldkrona",
+            "enhet": "st",
+            "ursprung": "Dvärgamynt",
+            "metall": "Guld",
+            "silver_varde": 360,
+            "vikt": 0.034
+        },
+        "silverlod": {
+            "namn": "Silverlod",
+            "enhet": "st",
+            "ursprung": "Dvärgamynt",
+            "metall": "Silver",
+            "silver_varde": 7.5,
+            "vikt": 0.014
+        },
+        "dukat": {
+            "namn": "Dukat",
+            "enhet": "st",
+            "ursprung": "Cirefaliskt mynt",
+            "metall": "Guld",
+            "silver_varde": 160,
+            "vikt": 0.0151
+        },
+        "florin": {
+            "namn": "Florin",
+            "enhet": "st",
+            "ursprung": "Cirefaliskt mynt",
+            "metall": "Silver",
+            "silver_varde": 6,
+            "vikt": 0.0114
+        },
+        "dinar": {
+            "namn": "Dinar",
+            "enhet": "st",
+            "ursprung": "Cirefaliskt mynt",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "skilling": {
+            "namn": "Skilling",
+            "enhet": "st",
+            "ursprung": "Adasiermynt",
+            "metall": "Guld",
+            "silver_varde": 12,
+            "vikt": 0.0011
+        },
+        "penning": {
+            "namn": "Penning",
+            "enhet": "st",
+            "ursprung": "Adasiermynt",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "drakma": {
+            "namn": "Drakma",
+            "enhet": "st",
+            "ursprung": "Stora arkipelagen",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "gulddirham": {
+            "namn": "Gulddirham",
+            "enhet": "st",
+            "ursprung": "Mûhad, Momolan",
+            "metall": "Guld",
+            "silver_varde": 66,
+            "vikt": 0.006
+        },
+        "silverdirham": {
+            "namn": "Silverdirham",
+            "enhet": "st",
+            "ursprung": "Mûhad, Momolan",
+            "metall": "Silver",
+            "silver_varde": 2,
+            "vikt": 0.0038
+        },
+        "koppardirham": {
+            "namn": "Koppardirham",
+            "enhet": "st",
+            "ursprung": "Mûhad, Momolan",
+            "metall": "Koppar",
+            "silver_varde": 0.06,
+            "vikt": 0.0004
+        },
+        "narin": {
+            "namn": "Narin",
+            "enhet": "st",
+            "ursprung": "Kamor",
+            "metall": "Silver",
+            "silver_varde": 10,
+            "vikt": 0.0189
+        },
+        "olom": {
+            "namn": "Olom",
+            "enhet": "st",
+            "ursprung": "Kamor",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "sunuvai": {
+            "namn": "Sunuvai",
+            "enhet": "st",
+            "ursprung": "Alver",
+            "metall": "Siluna",
+            "silver_varde": 2,
+            "vikt": 0.01
+        },
+        "jarnstang": {
+            "namn": "Järnstang",
+            "enhet": "st",
+            "ursprung": "Alver",
+            "metall": "Järn",
+            "silver_varde": 0.5,
+            "vikt": 0.01
+        },
+        "khali": {
+            "namn": "Khali",
+            "enhet": "st",
+            "ursprung": "Thalamur",
+            "metall": "Guld",
+            "silver_varde": 15,
+            "vikt": 0.0014
+        },
+        "sekhra": {
+            "namn": "Sekhra",
+            "enhet": "st",
+            "ursprung": "Thalamur",
+            "metall": "Silver",
+            "silver_varde": 0.75,
+            "vikt": 0.0014
+        },
+        "remerier": {
+            "namn": "Remerier",
+            "enhet": "st",
+            "ursprung": "Consaber",
+            "metall": "Guld",
+            "silver_varde": 252,
+            "vikt": 0.024
+        },
+        "nakon": {
+            "namn": "Nakon",
+            "enhet": "st",
+            "ursprung": "Consaber",
+            "metall": "Guld",
+            "silver_varde": 12,
+            "vikt": 0.0011
+        },
+        "cador": {
+            "namn": "Cador",
+            "enhet": "st",
+            "ursprung": "Consaber",
+            "metall": "Silver",
+            "silver_varde": 4,
+            "vikt": 0.0076
+        },
+        "Silver": {
+            "namn": "Silver",
+            "enhet": "st",
+            "ursprung": "Consaber",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "kvarting": {
+            "namn": "Kvarting",
+            "enhet": "st",
+            "ursprung": "Consaber",
+            "metall": "Silver",
+            "silver_varde": 0.25,
+            "vikt": 0.0005
+        },
+        "kulg": {
+            "namn": "Kulg",
+            "enhet": "st",
+            "ursprung": "Tirakiskt mynt",
+            "metall": "Guld",
+            "silver_varde": 160,
+            "vikt": 0.0151
+        },
+        "drock": {
+            "namn": "Drock",
+            "enhet": "st",
+            "ursprung": "Tirakiskt mynt",
+            "metall": "Silver",
+            "silver_varde": 6,
+            "vikt": 0.0114
+        },
+        "trugg": {
+            "namn": "Trugg",
+            "enhet": "st",
+            "ursprung": "Tirakiskt mynt",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "bakla": {
+            "namn": "Bakla",
+            "enhet": "st",
+            "ursprung": "Tirakiskt mynt",
+            "metall": "brons",
+            "silver_varde": 68,
+            "vikt": 0.454
+        },
+        "corona": {
+            "namn": "Corona",
+            "enhet": "st",
+            "ursprung": "Ebhronitiskt mynt",
+            "metall": "Guld",
+            "silver_varde": 100,
+            "vikt": 0.0095
+        },
+        "sikel": {
+            "namn": "Sikel",
+            "enhet": "st",
+            "ursprung": "Ebhronitiskt mynt",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0019
+        },
+        "nebul": {
+            "namn": "Nebul",
+            "enhet": "st",
+            "ursprung": "Ebhronitiskt mynt",
+            "metall": "Silver",
+            "silver_varde": 0.25,
+            "vikt": 0.00095
+        },
+        "hirtajen": {
+            "namn": "Hirta-jen",
+            "enhet": "st",
+            "ursprung": "Aunuriskt mynt",
+            "metall": "Guld",
+            "silver_varde": 100,
+            "vikt": 0.01
+        },
+        "hirta": {
+            "namn": "Hirta",
+            "enhet": "st",
+            "ursprung": "Aunuriskt mynt",
+            "metall": "Guld",
+            "silver_varde": 20,
+            "vikt": 0.0018
+        },
+        "avric": {
+            "namn": "Avric",
+            "enhet": "st",
+            "ursprung": "Aunuriskt mynt",
+            "metall": "Silver",
+            "silver_varde": 10,
+            "vikt": 0.009
+        },
+        "gormec": {
+            "namn": "Gormec",
+            "enhet": "st",
+            "ursprung": "Aunuriskt mynt",
+            "metall": "Silver",
+            "silver_varde": 5,
+            "vikt": 0.006
+        },
+        "arita": {
+            "namn": "Arita",
+            "enhet": "st",
+            "ursprung": "Aunuriskt mynt",
+            "metall": "Silver",
+            "silver_varde": 1,
+            "vikt": 0.0015
+        },
+        "chraz": {
+            "namn": "Chraz",
+            "enhet": "st",
+            "ursprung": "Aunuriskt mynt",
+            "metall": "Koppar",
+            "silver_varde": 0.1,
+            "vikt": 0.001
+        },
+        "itae": {
+            "namn": "Itaei",
+            "enhet": "st",
+            "ursprung": "Tarhaiskt mynt",
+            "metall": "Guld",
+            "silver_varde": 180,
+            "vikt": 0.0166
+        },
+        "himan": {
+            "namn": "Himan",
+            "enhet": "st",
+            "ursprung": "Tarhaiskt mynt",
+            "metall": "Silver",
+            "silver_varde": 0.5,
+            "vikt": 0.0011
+        },
+        "jakauv": {
+            "namn": "Jakauv",
+            "enhet": "st",
+            "ursprung": "Taupiskt mynt",
+            "metall": "Guld",
+            "silver_varde": 200,
+            "vikt": 0.021
+        }
+    }
+}

--- a/template.json
+++ b/template.json
@@ -18,7 +18,8 @@
             "Sköld",
             "Rustning",
             "Utrustning",
-            "Skada"
+            "Skada",
+            "Valuta"
         ],
         "Egenskap": {},
         "Folkslag": {},
@@ -32,6 +33,7 @@
         "Sköld": {},
         "Rustning": {},
         "Utrustning": {},
-        "Skada": {}
+        "Skada": {},
+        "Valuta": {}
     }
 }

--- a/templates/actors/parts/rollperson-sheet-equipment.html
+++ b/templates/actors/parts/rollperson-sheet-equipment.html
@@ -64,26 +64,39 @@
     </div>
 
     <div class="item-box">
-        <div class="headline headline-background item-row">
-            <div class="pointer weapon-icon">
-                <a class="item-create" title="Lägg till myntbehållare" data-type="mynt">
+        <div class="headline headline-background item-row" style="line-height: 25px; width:100%;">
+            <div class="weapon-icon">
+                <a class="item-create" title="Lägg till valuta" data-type="valuta">
                     <i class="fa-solid fa-square-plus green"></i>
                 </a>
             </div>
-            <div>Pengar</div>            
+            <div style="width: 25px;">&nbsp;</div>
+            <div style="width: 125px;">Valuta</div>
+            <div style="width: 100px; padding-left: 25px;">Antal</div>
+            <div style="width: 75px; padding-left: 20px;">Värde</div>
+            <div style="width: 50px; padding-left: 20px;">Vikt</div>            
         </div>
 
-        {{#each actor.system.listdata.utrustning.mynt as |foremal key|}}
+        {{#each actor.system.listdata.valuta as |valuta key|}}
             <div class="item-row" style="line-height: 25px; width:100%;">
-                <div class="weapon-icon"><a class="item-edit" title="Editera myntbehållare" data-source="utrustning" data-itemid="{{foremal._id}}"><i class="icon fa-solid fa-pen-to-square"></i></a></div>
-                {{#if (eq foremal.system.beskrivning "")}}
+                <div class="weapon-icon"><a class="item-edit" title="Editera valuta" data-source="valuta" data-itemid="{{valuta._id}}"><i class="icon fa-solid fa-pen-to-square"></i></a></div>
+                {{#if (eq valuta.system.beskrivning "")}}
                     <div class="weapon-icon"><i class="icon fa-regular fa-share"></i></div>
                 {{else}}
-                    <div class="weapon-icon"><a class="item-send" title="Skicka beskrivning" data-source="description" data-itemid="{{foremal._id}}"><i class="icon fa-solid fa-share"></i></a></div>
+                    <div class="weapon-icon"><a class="item-send" title="Skicka beskrivning" data-source="description" data-itemid="{{valuta._id}}"><i class="icon fa-solid fa-share"></i></a></div>
                 {{/if}}
-                <div class="active-icon"><input class="pointer item-active" name="foremal.system.installningar.buren" type="checkbox" data-itemid="{{foremal._id}}" data-property="buren" {{isChecked foremal.system.installningar.buren}} /></div>
-                <div style="width: 125px;" data-source="utrustning data-itemid="{{foremal._id}}">{{foremal.name}}</div>
-                <div><input class="attribute-value editable item-alter" type="text" value="{{foremal.system.volym.antal}}" data-itemid="{{foremal._id}}" data-property="volym.antal" data-datatype="Number" />{{foremal.system.volym.enhet}}</div>
+                <div class="active-icon">
+                    <input class="pointer item-active" 
+                           name="valuta.system.installningar.buren" 
+                           type="checkbox" 
+                           data-itemid="{{valuta._id}}" 
+                           data-property="buren" 
+                           {{isChecked valuta.system.installningar.buren}} />
+                </div>
+                <div style="width: 125px;" data-source="valuta" data-itemid="{{valuta._id}}">{{valuta.name}}</div>
+                <div style="width: 100px;"><input class="attribute-value editable item-alter" type="text" value="{{valuta.system.antal}}" data-itemid="{{valuta._id}}" data-property="antal" data-datatype="Number" /> st</div>
+                <div style="width: 75px;">{{formatDecimal (multiplicate valuta.system.silver_varde valuta.system.antal)}} sm</div>
+                <div style="width: 50px;">{{formatDecimal (multiplicate valuta.system.vikt valuta.system.antal)}} kg</div>
             </div>
         {{/each}}
     </div>

--- a/templates/items/utrustning-sheet.html
+++ b/templates/items/utrustning-sheet.html
@@ -128,9 +128,6 @@
                     {{#if (eq data.system.typ "kongelat")}}
                         <div class="information-area top-sidetext">KONGELAT</div>
                     {{/if}}
-                    {{#if (eq data.system.typ "mynt")}}
-                        <div class="information-area top-sidetext">MYNT</div>
-                    {{/if}}
                     {{#if (eq data.system.typ "utrustning")}}
                         <div class="information-area top-sidetext">UTRUSTNING</div>
                     {{/if}}

--- a/templates/items/valuta-sheet.html
+++ b/templates/items/valuta-sheet.html
@@ -1,0 +1,58 @@
+<form class="{{cssClass}}" autocomplete="off">
+    <div class="sheet-item">
+        <header class="sheet-header item-top">
+            <div class="clear" style="display: flex;">
+                <div class="pullLeft" style="min-width: 110px;">
+                    <img src="{{item.img}}" class="item img-block" />
+                </div>
+
+                <div class="pullLeft" style="min-width: 270px;">
+                    <div class="item-property-area number-value-text floating-label-group">
+                        <select class="text-value inputdata" name="name" data-source="valuta">
+                            <option value="">- Välj valuta -</option>
+                            {{#each (getCurrencyList EON.CONFIG.datavaluta)}}
+                                <option value="{{this.namn}}" {{#if (eq ../item.name this.namn)}}selected{{/if}}>
+                                    {{this.namn}} ({{this.ursprung}})
+                                </option>
+                            {{/each}}
+                        </select>
+                        <span class="floating-label">Valuta</span>
+                    </div>
+
+                    <div class="item-property-area number-value-text floating-label-group">
+                        <input class="attribute-value" name="system.metall" type="text" value="{{data.system.metall}}" data-dtype="String" readonly />
+                        <span class="floating-label">Metall</span>
+                    </div>
+
+                    <div class="item-property-area number-value-text floating-label-group">
+                        <input class="attribute-value" name="system.silver_varde" type="text" value="{{data.system.silver_varde}}" data-dtype="Number" readonly />
+                        <span class="floating-label">Silvervärde</span>
+                    </div>
+
+                    <div class="item-property-area number-value-text floating-label-group">
+                        <input class="attribute-value editable" name="system.antal" type="text" value="{{data.system.antal}}" data-dtype="Number" />
+                        <span class="floating-label">Antal</span>
+                    </div>
+
+                    <div class="item-property-area number-value-text floating-label-group">
+                        <input class="attribute-value" name="system.vikt" type="text" value="{{data.system.vikt}}" data-dtype="Number" readonly />
+                        <span class="floating-label">Vikt (st/kg)</span>
+                    </div>
+                </div>
+
+                <div class="pullLeft" style="flex-grow: 1; text-align: right;">
+                    {{#if hasActor}}
+                        <div class="pointer red item-delete large-icon" data-itemid="{{item._id}}"><i class="icon fa-solid fa-trash-can"></i></div>
+                    {{/if}}     
+                    <div class="information-area top-sidetext">VALUTA</div>
+                </div>
+            </div>
+        </header>
+        
+        <section class="item-body">    
+            <div style="width: 450px;">
+                {{> "systems/eon-test/templates/items/parts/items-description.html"}}
+            </div>
+        </section>
+    </div>
+</form>


### PR DESCRIPTION
Lagt till nytt item: Valuta.
Detta för att friställa Valuta från övrig utrustning då de har olika egenskaper.

Samtliga mynts data är hämtad från Eon 3, spelarboken, där vikt, värde och metall listas.

Denna ändring lägger även till myntens vikt till belastning
Samt så beräknas varje mynt typs totala värde ihop för att göra det lättare för spelaren att veta hur mycket deras mynt är värda.

![Screenshot from 2024-10-28 23-03-21](https://github.com/user-attachments/assets/57d2725d-ade2-40b8-ac2d-520aa6980df7)
