### PR TITLE
Lägga till försvarstekniker

### DIFF
--- a/templates/dialogs/dialog-weapon-roll.html
+++ b/templates/dialogs/dialog-weapon-roll.html
@@ -33,13 +33,31 @@
                         {{/if}}
                     </div>
                 {{/if}}
+
+                {{#if object.isdefence}}
+                    <div class="attack-info centerText" style="margin-top: 10px;">
+                        {{#if (eq object.attacktype 'defensivt')}}
+                            <div>Utmattning +1</div>
+                            <div>Färdighetstärningar +1T6</div>
+                            <div>Lyckas med minst 2 Övertag för att bli anfallare</div>
+                        {{else if (eq object.attacktype 'kontring')}}
+                            <div>Utmattning +1</div>
+                            <div>Färdighetstärningar -1T6</div>
+                            <div>Blir alltid anfallare, oavsett utfall</div>
+                        {{else if (eq object.attacktype 'normal')}}
+                            <div>Lyckas försvara för att bli anfallare</div>
+                        {{/if}}
+                    </div>
+                {{/if}}
             </div>
 
             <div class="dialog-area centerText">
                 <div class="clear">
                     <button class="three-button pullLeft mode {{#if object.isattack}}active{{/if}}" data-type="attack">Anfall</button>
                     <button class="three-button pullLeft mode {{#if object.isdamage}}active{{/if}}" data-type="damage">Skada</button>
-                    <button class="three-button pullLeft mode {{#if object.isdefence}}active{{/if}}" data-type="defence">Försvar</button>
+                    {{#unless object.vapen.isRangedWeapon}}
+                        <button class="three-button pullLeft mode {{#if object.isdefence}}active{{/if}}" data-type="defence">Försvar</button>
+                    {{/unless}}
                 </div>
 
                 <div id="attack_area" class="clear" style="height: 40px;">
@@ -55,18 +73,31 @@
                         {{/if}}
                     {{else}}  
                         {{#if object.isattack}}
+                            {{#unless object.vapen.isRangedWeapon}}
+                                <button class="attacktype three-button pullLeft {{#if (or (not object.attacktype) (eq object.attacktype 'normal'))}}active{{/if}}" 
+                                        data-type="normal" 
+                                        title="standard">Standard</button>
+                                <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'tungt')}}active{{/if}}" 
+                                        data-type="tungt" 
+                                        title="Utmattning +2&#10;Skada +2T6&#10;Färdighetstärningar -1T6">Kraftfult</button>
+                                <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'snabbt')}}active{{/if}}" 
+                                        data-type="snabbt" 
+                                        title="Utmattning +1&#10;Skada -1T6&#10;Färdighetstärningar +1T6">Snabbt</button>
+                                <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'grupp')}}active{{/if}}" 
+                                        data-type="grupp" 
+                                        title="Utmattning +1&#10;Färdighetstärningar -1T6">Gruppanfall</button>
+                            {{/unless}}
+                        {{/if}}
+                        {{#if object.isdefence}}
                             <button class="attacktype three-button pullLeft {{#if (or (not object.attacktype) (eq object.attacktype 'normal'))}}active{{/if}}" 
                                     data-type="normal" 
-                                    title="standard">Standard</button>
-                            <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'tungt')}}active{{/if}}" 
-                                    data-type="tungt" 
-                                    title="Utmattning +2&#10;Skada +2T6&#10;Färdighetstärningar -1T6">Kraftfult</button>
-                            <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'snabbt')}}active{{/if}}" 
-                                    data-type="snabbt" 
-                                    title="Utmattning +1&#10;Skada -1T6&#10;Färdighetstärningar +1T6">Snabbt</button>
-                            <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'grupp')}}active{{/if}}" 
-                                    data-type="grupp" 
-                                    title="Utmattning +1&#10;Färdighetstärningar -1T6">Gruppanfall</button>
+                                    title="Utmattning +0&#10;Färdighetstärningar +0">Standard</button>
+                            <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'defensivt')}}active{{/if}}" 
+                                    data-type="defensivt" 
+                                    title="Utmattning +1&#10;Färdighetstärningar +1T6">Defensivt</button>
+                            <button class="attacktype three-button pullLeft {{#if (eq object.attacktype 'kontring')}}active{{/if}}" 
+                                    data-type="kontring" 
+                                    title="Utmattning +1&#10;Färdighetstärningar -1T6">Kontring</button>
                         {{/if}}
                     {{/if}}
                 </div>


### PR DESCRIPTION
La till försvarstaktiker när man försvarar sig med närstridsvapen/sköld.

Denna pr innehåller även:
- Tog bort möjligheten att försvara sig med avståndsvapen.
- Fixade default skada för närstridsvapen, defaultar till den skade typ som gör mest skada, om man inte aktivt väljer någon.
- Fixade en bug med vapenskada som satt vapenskadan till 0T6 om man inte valde anfalls typ.
  - Detta kanske löser problemet i denna [Issue](https://github.com/JohanFalt/Foundry_EON-RPG/issues/186) men har inte verifierat detta.

