### PR TITLE
Bugfix rulla som actor, inte user

### DIFF
--- a/module/dialogs/dialog-weapon-roll.js
+++ b/module/dialogs/dialog-weapon-roll.js
@@ -712,6 +712,7 @@ export class DialogWeaponRoll extends FormApplication {
         roll.action = this.object.vapennamn;                       
 
         roll.info = this.object.vapen.system.egenskaper;
+        roll.actorName = this.actor.name;
 
         var grundvarde = "";
 

--- a/module/dice-helper.js
+++ b/module/dice-helper.js
@@ -181,6 +181,7 @@ export class DiceRollContainer {
         this.svarighet = 0;
 		this.dicetype = "d6";
 		this.obRoll = true;
+        this.actorName = actor.name;
     }
 }
 
@@ -336,10 +337,13 @@ export async function RollDice(diceRoll) {
     const html = await renderTemplate(template, templateData);
 
     const chatData = {
-        //type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-        rolls: allDices,
+        user: game.user.id,
+        speaker: {
+            actor: diceRoll.actor?.id,
+            token: diceRoll.actor?.token?.id,
+            alias: diceRoll.actorName
+        },
         content: html,
-        speaker: ChatMessage.getSpeaker(),
         rollMode: game.settings.get("core", "rollMode")        
     };
     ChatMessage.applyRollMode(chatData, "roll");


### PR DESCRIPTION
Färdigheter, Härleda attribute, anfall, försvar och skada rullar nu som Actor och inte User.

Se [Issue](https://github.com/JohanFalt/Foundry_EON-RPG/issues/189)